### PR TITLE
Add Showcase and TradePost columns

### DIFF
--- a/prisma/migrations/20260201050420_add_tradepost_and_showcase_columns/migration.sql
+++ b/prisma/migrations/20260201050420_add_tradepost_and_showcase_columns/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "CollectionEntry" ADD COLUMN     "forTrade" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "showcase" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Set" ALTER COLUMN "official" SET DEFAULT 0,
+ALTER COLUMN "total" SET DEFAULT 0;

--- a/prisma/migrations/20260201051649_new_socials/migration.sql
+++ b/prisma/migrations/20260201051649_new_socials/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "discord" TEXT,
+ADD COLUMN     "whatsapp" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,8 @@ model User {
   id         String            @id @db.Uuid
   username   String?           @unique
   email      String            @unique
+  whatsapp   String?
+  discord    String?
   collection CollectionEntry[]
   wishlist   WishlistEntry[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,11 +61,13 @@ model CollectionEntry {
   quantity  Int     @default(1)
   condition String?
   variant   String?
+  forTrade  Boolean @default(false)
+  showcase  Boolean @default(false)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([userId, cardId, condition, variant])
+  @@unique([userId, cardId, condition, variant]) 
 }
 
 model WishlistEntry {


### PR DESCRIPTION
## PR Description

Adding capability for database to differentiate cards in a user's collection between for trade and not for trade. Also added ability to signify which user's cards to put on their profile showcase.

#### Summary of changes

<!-- What was changed and what are their effects? -->
Originally, the idea was to create separate tables that stored a user's for-trade cards, but we will first try a boolean value associated with the card a user owns that signifies whether the card is up for trading. Similar with the showcase cards.

#### Motivation for changes

<!-- Why were the changes made? -->

#### Links

<!-- Replace ### with the actual ticket number. It will automatically be linked to JIRA -->
<!-- To link to PR 123, simply type #123, GitHub will suggest the PR -->

JIRA ticket: [JIRA-###]
https://kollec-app.atlassian.net/browse/JIRA-61
Other PR:

#### Testing Description

<!-- Describe how the changes have been tested + add screen capture and/or recording whenever possible -->

#### Checklist

- [ ] PR Summary
- [ ] Motivation
- [ ] Links
- [ ] Testing Description
- [ ] Unit Test
- [ ] Screen capture and/or recording
