### PR TITLE
Fix same username error message + make location not required

### DIFF
--- a/src/app/personal-profile/edit-profile/page.tsx
+++ b/src/app/personal-profile/edit-profile/page.tsx
@@ -119,7 +119,13 @@ const PersonalProfileScreen: React.FC = () => {
                 data: JSON.stringify({ id: session?.user?.id, ...data })
             })
 
-            if (res.status !== 200) {
+            if (res.data.error && res.data.error.code === 'P2002') {
+                setError('username', {
+                    type: 'username_taken',
+                    message:
+                        'An account with this username already exists. Please pick a different username.'
+                })
+            } else if (res.status !== 200) {
                 const err = res.data.error
                 console.error(err)
             } else {
@@ -429,18 +435,11 @@ const PersonalProfileScreen: React.FC = () => {
                         Write a little about yourself for others to see.
                     </Field.HelperText>
                 </Field.Root>
-                <Field.Root
-                    required
-                    invalid={!!errors.location}
-                    position="relative"
-                >
-                    <Field.Label>
-                        Location <Field.RequiredIndicator />
-                    </Field.Label>
+                <Field.Root invalid={!!errors.location} position="relative">
+                    <Field.Label>Location</Field.Label>
                     <Controller
                         name="location"
                         control={control}
-                        rules={{ required: 'Location is required' }}
                         render={({ field }) => (
                             <Input
                                 type="text"

--- a/src/components/auth/RegistrationForm.tsx
+++ b/src/components/auth/RegistrationForm.tsx
@@ -75,11 +75,7 @@ const RegistrationForm = () => {
             }).then((res) => res.data)
 
             // Check for username uniqueness error
-            if (
-                response.error &&
-                response.message &&
-                response.message.code === 'P2002'
-            ) {
+            if (response.error && response.error.code === 'P2002') {
                 setError('root', {
                     type: 'username_taken',
                     message:

--- a/src/components/auth/__tests__/RegistrationForm.test.tsx
+++ b/src/components/auth/__tests__/RegistrationForm.test.tsx
@@ -141,8 +141,7 @@ describe('RegistrationForm', () => {
         ;(CapacitorHttp.post as jest.Mock).mockResolvedValue({
             ok: true,
             data: {
-                error: true,
-                message: { code: 'P2002' }
+                error: { code: 'P2002' }
             }
         })
 


### PR DESCRIPTION
## PR Description

#### Summary of changes

<!-- What was changed and what are their effects? -->
- Removed required condition for location field in edit profile
- Added/Fixed same username error handling in user profile & registration form page

#### Motivation for changes

<!-- Why were the changes made? -->
Bug fixes!! 😄 

#### Links

<!-- Replace ### with the actual ticket number. It will automatically be linked to JIRA -->
<!-- To link to PR 123, simply type #123, GitHub will suggest the PR -->

JIRA ticket: [JIRA-115], [JIRA-108]

#### Testing Description

<!-- Describe how the changes have been tested + add screen capture and/or recording whenever possible -->
Tested locally that error message now displays when trying to save with an existing username. 

<img width="410" height="160" alt="image" src="https://github.com/user-attachments/assets/80e19a68-488c-4c1c-bf20-86b05663ec07" />

Tested location is no longer a required field

<img width="406" height="102" alt="image" src="https://github.com/user-attachments/assets/53c62d04-e01e-418e-a586-ba9f47cabaff" />

#### Checklist

- [x] PR Summary
- [x] Motivation
- [x] Links
- [x] Testing Description
- [x] Unit Test
- [x] Screen capture and/or recording


[JIRA-115]: https://kollec-app.atlassian.net/browse/JIRA-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JIRA-108]: https://kollec-app.atlassian.net/browse/JIRA-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ