### PR TITLE
[JIRA-115] Fix empty location handling

### DIFF
--- a/src/app/api/edit-profile/route.ts
+++ b/src/app/api/edit-profile/route.ts
@@ -44,7 +44,9 @@ export async function PATCH(request: Request) {
         if (typeof bio === 'string') data.bio = bio
         if (typeof location === 'string') data.location = location
         if (typeof latitude === 'number') data.latitude = latitude
+        if (latitude === null) data.latitude = null
         if (typeof longitude === 'number') data.longitude = longitude
+        if (longitude === null) data.longitude = null
         if (typeof instagram === 'string') data.instagram = instagram
         if (typeof x === 'string') data.x = x
         if (typeof facebook === 'string') data.facebook = facebook
@@ -53,6 +55,8 @@ export async function PATCH(request: Request) {
         if (typeof profilePic === 'number') data.profile_pic = profilePic
         if (typeof visibility === 'string')
             data.visibility = visibility as FormValues['visibility']
+
+        console.log('Data to update:', data)
 
         const updated = await prisma.user.update({
             where: { id: identifier },

--- a/src/app/api/edit-profile/route.ts
+++ b/src/app/api/edit-profile/route.ts
@@ -56,8 +56,6 @@ export async function PATCH(request: Request) {
         if (typeof visibility === 'string')
             data.visibility = visibility as FormValues['visibility']
 
-        console.log('Data to update:', data)
-
         const updated = await prisma.user.update({
             where: { id: identifier },
             data

--- a/src/app/personal-profile/edit-profile/page.tsx
+++ b/src/app/personal-profile/edit-profile/page.tsx
@@ -55,8 +55,8 @@ const PersonalProfileScreen: React.FC = () => {
             username: '',
             bio: '',
             location: '',
-            longitude: NaN,
-            latitude: NaN,
+            longitude: null,
+            latitude: null,
             instagram: '',
             x: '',
             facebook: '',
@@ -89,10 +89,10 @@ const PersonalProfileScreen: React.FC = () => {
             value.trim() === ''
         ) {
             setSelectedPlace(null)
-            setValue('latitude', NaN, {
+            setValue('latitude', null, {
                 shouldValidate: false
             })
-            setValue('longitude', NaN, {
+            setValue('longitude', null, {
                 shouldValidate: false
             })
         }
@@ -154,8 +154,8 @@ const PersonalProfileScreen: React.FC = () => {
                     email: data.email ?? '',
                     bio: data.bio ?? '',
                     location: data.location ?? '',
-                    latitude: data.latitude ?? NaN,
-                    longitude: data.longitude ?? NaN,
+                    latitude: data.latitude ?? null,
+                    longitude: data.longitude ?? null,
                     instagram: data.instagram ?? '',
                     x: data.x ?? '',
                     facebook: data.facebook ?? '',

--- a/src/app/personal-profile/edit-profile/page.tsx
+++ b/src/app/personal-profile/edit-profile/page.tsx
@@ -84,7 +84,10 @@ const PersonalProfileScreen: React.FC = () => {
     const handleInputChange = (value: string) => {
         setShowLocationSuggestions(value)
         setValue('location', value, { shouldValidate: true })
-        if (selectedPlace && value !== selectedPlace.formatted) {
+        if (
+            (selectedPlace && value !== selectedPlace.formatted) ||
+            value.trim() === ''
+        ) {
             setSelectedPlace(null)
             setValue('latitude', NaN, {
                 shouldValidate: false

--- a/src/types/personal-profile.ts
+++ b/src/types/personal-profile.ts
@@ -5,8 +5,8 @@ export interface FormValues {
     username: string
     bio: string
     location: string
-    longitude: number
-    latitude: number
+    longitude: number | null
+    latitude: number | null
     instagram: string
     x: string
     facebook: string


### PR DESCRIPTION
## PR Description

#### Summary of changes

<!-- What was changed and what are their effects? -->
Sets longitude and latitude to null when the location value is empty, then explicitly set longitude and latitude to null when passing the data to the prisma db update in the API if the received data is also null.

#### Motivation for changes

<!-- Why were the changes made? -->
If the user removes their location, it should also clear the longitude and latitude fields.

#### Links

<!-- Replace ### with the actual ticket number. It will automatically be linked to JIRA -->
<!-- To link to PR 123, simply type #123, GitHub will suggest the PR -->

JIRA ticket: [JIRA-115]
Other PR: #102 

#### Testing Description

<!-- Describe how the changes have been tested + add screen capture and/or recording whenever possible -->
Tested by checking PATCH payload with null longitude & latitude + local db fields reflect the null fields whenever location is empty

#### Checklist

- [x] PR Summary
- [x] Motivation
- [x] Links
- [x] Testing Description
- [ ] Unit Test
- [ ] Screen capture and/or recording


[JIRA-115]: https://kollec-app.atlassian.net/browse/JIRA-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ